### PR TITLE
feat: human-readable log rendering with color-coded output

### DIFF
--- a/internal/tui/renderer.go
+++ b/internal/tui/renderer.go
@@ -1,0 +1,401 @@
+// Package tui provides terminal UI components for LogPilot.
+package tui
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/clarabennett2626/logpilot/internal/parser"
+)
+
+// TimestampFormat controls how timestamps are displayed.
+type TimestampFormat int
+
+const (
+	// TimestampRelative shows "2m ago", "3h ago", etc.
+	TimestampRelative TimestampFormat = iota
+	// TimestampISO shows ISO 8601 format.
+	TimestampISO
+	// TimestampLocal shows local time format.
+	TimestampLocal
+)
+
+// Theme represents terminal color theme.
+type Theme int
+
+const (
+	ThemeDark Theme = iota
+	ThemeLight
+)
+
+// ANSIMode controls how ANSI escape codes in source logs are handled.
+type ANSIMode int
+
+const (
+	ANSIStrip ANSIMode = iota
+	ANSIPassthrough
+)
+
+// WrapMode controls how long lines are handled.
+type WrapMode int
+
+const (
+	WrapTruncate WrapMode = iota
+	WrapWrap
+)
+
+// RenderConfig holds rendering configuration.
+type RenderConfig struct {
+	TimestampFormat TimestampFormat
+	Theme          Theme
+	ANSIMode       ANSIMode
+	WrapMode       WrapMode
+	TerminalWidth  int
+	FieldOrder     []string // ordered field names to display; empty = alphabetical
+	ShowAllFields  bool     // when false, extra fields are collapsed
+	Now            func() time.Time // for testing; defaults to time.Now
+}
+
+// DefaultConfig returns a sensible default configuration.
+func DefaultConfig() RenderConfig {
+	return RenderConfig{
+		TimestampFormat: TimestampLocal,
+		Theme:          ThemeDark,
+		ANSIMode:       ANSIStrip,
+		WrapMode:       WrapTruncate,
+		TerminalWidth:  120,
+		ShowAllFields:  false,
+		Now:            time.Now,
+	}
+}
+
+// Renderer renders parsed log entries as styled terminal output.
+type Renderer struct {
+	config RenderConfig
+	styles themeStyles
+}
+
+type themeStyles struct {
+	debug     lipgloss.Style
+	info      lipgloss.Style
+	warn      lipgloss.Style
+	errLevel  lipgloss.Style
+	fatal     lipgloss.Style
+	timestamp lipgloss.Style
+	message   lipgloss.Style
+	fieldKey  lipgloss.Style
+	fieldVal  lipgloss.Style
+	separator lipgloss.Style
+}
+
+func darkStyles() themeStyles {
+	return themeStyles{
+		debug:     lipgloss.NewStyle().Foreground(lipgloss.Color("245")),            // gray
+		info:      lipgloss.NewStyle().Foreground(lipgloss.Color("39")),             // blue
+		warn:      lipgloss.NewStyle().Foreground(lipgloss.Color("220")),            // yellow
+		errLevel:  lipgloss.NewStyle().Foreground(lipgloss.Color("196")),            // red
+		fatal:     lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true),  // red bold
+		timestamp: lipgloss.NewStyle().Foreground(lipgloss.Color("243")),            // dim gray
+		message:   lipgloss.NewStyle().Foreground(lipgloss.Color("255")),            // white
+		fieldKey:  lipgloss.NewStyle().Foreground(lipgloss.Color("117")),            // light blue
+		fieldVal:  lipgloss.NewStyle().Foreground(lipgloss.Color("252")),            // light gray
+		separator: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),            // dark gray
+	}
+}
+
+func lightStyles() themeStyles {
+	return themeStyles{
+		debug:     lipgloss.NewStyle().Foreground(lipgloss.Color("244")),
+		info:      lipgloss.NewStyle().Foreground(lipgloss.Color("27")),
+		warn:      lipgloss.NewStyle().Foreground(lipgloss.Color("172")),
+		errLevel:  lipgloss.NewStyle().Foreground(lipgloss.Color("160")),
+		fatal:     lipgloss.NewStyle().Foreground(lipgloss.Color("160")).Bold(true),
+		timestamp: lipgloss.NewStyle().Foreground(lipgloss.Color("242")),
+		message:   lipgloss.NewStyle().Foreground(lipgloss.Color("0")),
+		fieldKey:  lipgloss.NewStyle().Foreground(lipgloss.Color("25")),
+		fieldVal:  lipgloss.NewStyle().Foreground(lipgloss.Color("237")),
+		separator: lipgloss.NewStyle().Foreground(lipgloss.Color("249")),
+	}
+}
+
+// NewRenderer creates a new Renderer with the given config.
+func NewRenderer(config RenderConfig) *Renderer {
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.TerminalWidth <= 0 {
+		config.TerminalWidth = 120
+	}
+	var styles themeStyles
+	if config.Theme == ThemeLight {
+		styles = lightStyles()
+	} else {
+		styles = darkStyles()
+	}
+	return &Renderer{config: config, styles: styles}
+}
+
+// ansiRegex matches ANSI escape sequences.
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// StripANSI removes ANSI escape codes from a string.
+func StripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// RenderEntry renders a single LogEntry as a styled string.
+func (r *Renderer) RenderEntry(entry parser.LogEntry) string {
+	var parts []string
+
+	// Level badge
+	levelStr := r.renderLevel(entry.Level)
+	if levelStr != "" {
+		parts = append(parts, levelStr)
+	}
+
+	// Timestamp
+	if !entry.Timestamp.IsZero() {
+		ts := r.renderTimestamp(entry.Timestamp)
+		parts = append(parts, ts)
+	}
+
+	// Message
+	msg := entry.Message
+	if msg == "" {
+		msg = entry.Raw
+	}
+	if r.config.ANSIMode == ANSIStrip {
+		msg = StripANSI(msg)
+	}
+	if msg != "" {
+		parts = append(parts, r.styles.message.Render(msg))
+	}
+
+	// Fields
+	if r.config.ShowAllFields && len(entry.Fields) > 0 {
+		fieldStr := r.renderFields(entry.Fields)
+		if fieldStr != "" {
+			parts = append(parts, fieldStr)
+		}
+	}
+
+	line := strings.Join(parts, r.styles.separator.Render(" │ "))
+
+	// Truncate or wrap
+	line = r.applyWrap(line)
+
+	return line
+}
+
+// RenderEntryPlain renders without styling (for piping/testing visible text).
+func (r *Renderer) RenderEntryPlain(entry parser.LogEntry) string {
+	var parts []string
+
+	if entry.Level != "" {
+		parts = append(parts, strings.ToUpper(normalizeLevel(entry.Level)))
+	}
+	if !entry.Timestamp.IsZero() {
+		parts = append(parts, r.formatTimestamp(entry.Timestamp))
+	}
+	msg := entry.Message
+	if msg == "" {
+		msg = entry.Raw
+	}
+	if r.config.ANSIMode == ANSIStrip {
+		msg = StripANSI(msg)
+	}
+	if msg != "" {
+		parts = append(parts, msg)
+	}
+	if r.config.ShowAllFields && len(entry.Fields) > 0 {
+		parts = append(parts, r.renderFieldsPlain(entry.Fields))
+	}
+	return strings.Join(parts, " │ ")
+}
+
+// CollapsedFieldCount returns how many extra fields would be hidden.
+func CollapsedFieldCount(entry parser.LogEntry) int {
+	return len(entry.Fields)
+}
+
+func (r *Renderer) renderLevel(level string) string {
+	norm := normalizeLevel(level)
+	label := fmt.Sprintf("%-5s", strings.ToUpper(norm))
+	switch norm {
+	case "debug":
+		return r.styles.debug.Render(label)
+	case "info":
+		return r.styles.info.Render(label)
+	case "warn", "warning":
+		return r.styles.warn.Render(label)
+	case "error":
+		return r.styles.errLevel.Render(label)
+	case "fatal", "panic", "critical":
+		return r.styles.fatal.Render(label)
+	default:
+		if level == "" {
+			return ""
+		}
+		return r.styles.message.Render(label)
+	}
+}
+
+func normalizeLevel(level string) string {
+	l := strings.ToLower(strings.TrimSpace(level))
+	switch l {
+	case "warning":
+		return "warn"
+	case "critical", "panic":
+		return "fatal"
+	default:
+		return l
+	}
+}
+
+func (r *Renderer) renderTimestamp(t time.Time) string {
+	return r.styles.timestamp.Render(r.formatTimestamp(t))
+}
+
+func (r *Renderer) formatTimestamp(t time.Time) string {
+	switch r.config.TimestampFormat {
+	case TimestampRelative:
+		return relativeTime(t, r.config.Now())
+	case TimestampISO:
+		return t.Format(time.RFC3339)
+	case TimestampLocal:
+		return t.Format("15:04:05")
+	default:
+		return t.Format(time.RFC3339)
+	}
+}
+
+func relativeTime(t time.Time, now time.Time) string {
+	d := now.Sub(t)
+	if d < 0 {
+		d = -d
+		return formatDuration(d) + " from now"
+	}
+	if d < time.Second {
+		return "just now"
+	}
+	return formatDuration(d) + " ago"
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		s := int(d.Seconds())
+		return fmt.Sprintf("%ds", s)
+	case d < time.Hour:
+		m := int(d.Minutes())
+		return fmt.Sprintf("%dm", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		return fmt.Sprintf("%dh", h)
+	default:
+		days := int(d.Hours() / 24)
+		return fmt.Sprintf("%dd", days)
+	}
+}
+
+func (r *Renderer) renderFields(fields map[string]string) string {
+	ordered := r.orderedFieldKeys(fields)
+	var parts []string
+	for _, k := range ordered {
+		v := fields[k]
+		part := r.styles.fieldKey.Render(k) + r.styles.separator.Render("=") + r.styles.fieldVal.Render(v)
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, " ")
+}
+
+func (r *Renderer) renderFieldsPlain(fields map[string]string) string {
+	ordered := r.orderedFieldKeys(fields)
+	var parts []string
+	for _, k := range ordered {
+		parts = append(parts, k+"="+fields[k])
+	}
+	return strings.Join(parts, " ")
+}
+
+func (r *Renderer) orderedFieldKeys(fields map[string]string) []string {
+	if len(r.config.FieldOrder) > 0 {
+		var result []string
+		seen := make(map[string]bool)
+		for _, k := range r.config.FieldOrder {
+			if _, ok := fields[k]; ok {
+				result = append(result, k)
+				seen[k] = true
+			}
+		}
+		// append remaining keys alphabetically
+		remaining := make([]string, 0, len(fields))
+		for k := range fields {
+			if !seen[k] {
+				remaining = append(remaining, k)
+			}
+		}
+		sortStrings(remaining)
+		result = append(result, remaining...)
+		return result
+	}
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	return keys
+}
+
+// simple insertion sort to avoid importing sort package
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+func (r *Renderer) applyWrap(line string) string {
+	if r.config.WrapMode == WrapTruncate && r.config.TerminalWidth > 0 {
+		// Strip ANSI to measure visible length, but truncate the raw string
+		visible := StripANSI(line)
+		if len(visible) > r.config.TerminalWidth {
+			// Truncate by visible chars. Rough approach: walk raw string.
+			return truncateToWidth(line, r.config.TerminalWidth-1) + "…"
+		}
+	}
+	// WrapWrap: lipgloss handles wrapping naturally, just return as-is
+	return line
+}
+
+// truncateToWidth truncates a string with ANSI codes to fit a visible width.
+func truncateToWidth(s string, width int) string {
+	visible := 0
+	inEscape := false
+	var result []byte
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		if b == '\x1b' {
+			inEscape = true
+			result = append(result, b)
+			continue
+		}
+		if inEscape {
+			result = append(result, b)
+			if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') {
+				inEscape = false
+			}
+			continue
+		}
+		if visible >= width {
+			break
+		}
+		result = append(result, b)
+		visible++
+	}
+	return string(result)
+}

--- a/internal/tui/renderer_test.go
+++ b/internal/tui/renderer_test.go
@@ -1,0 +1,290 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clarabennett2626/logpilot/internal/parser"
+)
+
+var fixedNow = time.Date(2026, 2, 17, 20, 0, 0, 0, time.UTC)
+
+func fixedTime() time.Time { return fixedNow }
+
+func plainRenderer(opts ...func(*RenderConfig)) *Renderer {
+	cfg := DefaultConfig()
+	cfg.Now = fixedTime
+	cfg.TerminalWidth = 200 // wide enough to avoid truncation
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return NewRenderer(cfg)
+}
+
+func TestRenderLevel_Colors(t *testing.T) {
+	r := plainRenderer()
+	tests := []struct {
+		level    string
+		contains string
+	}{
+		{"debug", "DEBUG"},
+		{"INFO", "INFO"},
+		{"warn", "WARN"},
+		{"warning", "WARN"},
+		{"error", "ERROR"},
+		{"fatal", "FATAL"},
+		{"PANIC", "FATAL"},
+		{"critical", "FATAL"},
+	}
+	for _, tt := range tests {
+		entry := parser.LogEntry{Level: tt.level, Message: "test"}
+		out := r.RenderEntryPlain(entry)
+		if !strings.Contains(out, tt.contains) {
+			t.Errorf("level=%q: expected %q in output, got %q", tt.level, tt.contains, out)
+		}
+	}
+}
+
+func TestRenderTimestamp_Relative(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.TimestampFormat = TimestampRelative })
+	tests := []struct {
+		offset   time.Duration
+		contains string
+	}{
+		{0, "just now"},
+		{30 * time.Second, "30s ago"},
+		{5 * time.Minute, "5m ago"},
+		{3 * time.Hour, "3h ago"},
+		{48 * time.Hour, "2d ago"},
+	}
+	for _, tt := range tests {
+		ts := fixedNow.Add(-tt.offset)
+		entry := parser.LogEntry{Timestamp: ts, Message: "test"}
+		out := r.RenderEntryPlain(entry)
+		if !strings.Contains(out, tt.contains) {
+			t.Errorf("offset=%v: expected %q in %q", tt.offset, tt.contains, out)
+		}
+	}
+}
+
+func TestRenderTimestamp_ISO(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.TimestampFormat = TimestampISO })
+	ts := time.Date(2026, 2, 17, 15, 30, 45, 0, time.UTC)
+	entry := parser.LogEntry{Timestamp: ts, Message: "hello"}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "2026-02-17T15:30:45Z") {
+		t.Errorf("expected ISO timestamp in %q", out)
+	}
+}
+
+func TestRenderTimestamp_Local(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.TimestampFormat = TimestampLocal })
+	ts := time.Date(2026, 2, 17, 15, 30, 45, 0, time.UTC)
+	entry := parser.LogEntry{Timestamp: ts, Message: "hello"}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "15:30:45") {
+		t.Errorf("expected local time in %q", out)
+	}
+}
+
+func TestRenderFields_ShowAll(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.ShowAllFields = true })
+	entry := parser.LogEntry{
+		Level:   "info",
+		Message: "request handled",
+		Fields:  map[string]string{"method": "GET", "path": "/api", "status": "200"},
+	}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "method=GET") || !strings.Contains(out, "path=/api") || !strings.Contains(out, "status=200") {
+		t.Errorf("expected all fields in %q", out)
+	}
+}
+
+func TestRenderFields_Collapsed(t *testing.T) {
+	r := plainRenderer() // ShowAllFields = false
+	entry := parser.LogEntry{
+		Level:   "info",
+		Message: "request handled",
+		Fields:  map[string]string{"method": "GET", "path": "/api"},
+	}
+	out := r.RenderEntryPlain(entry)
+	if strings.Contains(out, "method=GET") {
+		t.Errorf("fields should be collapsed but got %q", out)
+	}
+}
+
+func TestCollapsedFieldCount(t *testing.T) {
+	entry := parser.LogEntry{
+		Fields: map[string]string{"a": "1", "b": "2", "c": "3"},
+	}
+	if got := CollapsedFieldCount(entry); got != 3 {
+		t.Errorf("expected 3 collapsed fields, got %d", got)
+	}
+}
+
+func TestFieldOrder(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) {
+		c.ShowAllFields = true
+		c.FieldOrder = []string{"status", "method"}
+	})
+	entry := parser.LogEntry{
+		Message: "req",
+		Fields:  map[string]string{"method": "GET", "path": "/api", "status": "200"},
+	}
+	out := r.RenderEntryPlain(entry)
+	statusIdx := strings.Index(out, "status=200")
+	methodIdx := strings.Index(out, "method=GET")
+	pathIdx := strings.Index(out, "path=/api")
+	if statusIdx == -1 || methodIdx == -1 || pathIdx == -1 {
+		t.Fatalf("missing fields in %q", out)
+	}
+	if statusIdx > methodIdx {
+		t.Error("status should come before method per FieldOrder")
+	}
+	if methodIdx > pathIdx {
+		t.Error("method should come before path (remaining sorted)")
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	input := "\x1b[31mERROR\x1b[0m something failed"
+	got := StripANSI(input)
+	if got != "ERROR something failed" {
+		t.Errorf("StripANSI=%q, want %q", got, "ERROR something failed")
+	}
+}
+
+func TestANSIPassthrough(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.ANSIMode = ANSIPassthrough })
+	entry := parser.LogEntry{Message: "\x1b[31mred text\x1b[0m"}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "\x1b[31m") {
+		t.Error("ANSI codes should pass through")
+	}
+}
+
+func TestANSIStrip(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.ANSIMode = ANSIStrip })
+	entry := parser.LogEntry{Message: "\x1b[31mred text\x1b[0m"}
+	out := r.RenderEntryPlain(entry)
+	if strings.Contains(out, "\x1b[") {
+		t.Error("ANSI codes should be stripped")
+	}
+	if !strings.Contains(out, "red text") {
+		t.Error("text content should remain")
+	}
+}
+
+func TestTruncation(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) {
+		c.TerminalWidth = 30
+		c.WrapMode = WrapTruncate
+	})
+	entry := parser.LogEntry{Message: "This is a very long message that should be truncated at the terminal width boundary"}
+	out := r.RenderEntry(entry)
+	plain := StripANSI(out)
+	// ellipsis "…" is 3 bytes in UTF-8 but 1 visible char
+	visibleLen := len([]rune(plain))
+	if visibleLen > 31 { // 30 visible + ellipsis
+		t.Errorf("expected truncated output <=31 runes, got %d: %q", visibleLen, plain)
+	}
+	if !strings.HasSuffix(plain, "…") {
+		t.Error("truncated output should end with ellipsis")
+	}
+}
+
+func TestWrapMode(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) {
+		c.TerminalWidth = 30
+		c.WrapMode = WrapWrap
+	})
+	entry := parser.LogEntry{Message: "This is a long message that should not be truncated in wrap mode"}
+	out := r.RenderEntry(entry)
+	plain := StripANSI(out)
+	if strings.HasSuffix(plain, "…") {
+		t.Error("wrap mode should not truncate")
+	}
+}
+
+func TestDarkTheme(t *testing.T) {
+	r := NewRenderer(RenderConfig{Theme: ThemeDark, TerminalWidth: 200, Now: fixedTime})
+	entry := parser.LogEntry{Level: "error", Message: "fail"}
+	out := r.RenderEntry(entry)
+	if !strings.Contains(out, "ERROR") {
+		t.Errorf("expected ERROR in output: %q", out)
+	}
+}
+
+func TestLightTheme(t *testing.T) {
+	r := NewRenderer(RenderConfig{Theme: ThemeLight, TerminalWidth: 200, Now: fixedTime})
+	entry := parser.LogEntry{Level: "info", Message: "ok"}
+	out := r.RenderEntry(entry)
+	if !strings.Contains(out, "INFO") {
+		t.Errorf("expected INFO in output: %q", out)
+	}
+}
+
+func TestRenderEntry_EmptyEntry(t *testing.T) {
+	r := plainRenderer()
+	entry := parser.LogEntry{}
+	out := r.RenderEntryPlain(entry)
+	if out != "" {
+		t.Errorf("empty entry should produce empty output, got %q", out)
+	}
+}
+
+func TestRenderEntry_RawFallback(t *testing.T) {
+	r := plainRenderer()
+	entry := parser.LogEntry{Raw: "raw log line here"}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "raw log line here") {
+		t.Errorf("should fall back to Raw when Message empty: %q", out)
+	}
+}
+
+func TestRenderEntry_FullIntegration(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) {
+		c.TimestampFormat = TimestampISO
+		c.ShowAllFields = true
+	})
+	entry := parser.LogEntry{
+		Timestamp: time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC),
+		Level:     "error",
+		Message:   "connection refused",
+		Fields:    map[string]string{"host": "db.local", "port": "5432"},
+		Format:    parser.FormatJSON,
+	}
+	out := r.RenderEntryPlain(entry)
+	for _, want := range []string{"ERROR", "2026-01-15T10:30:00Z", "connection refused", "host=db.local", "port=5432"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output %q", want, out)
+		}
+	}
+}
+
+func TestRelativeTime_Future(t *testing.T) {
+	r := plainRenderer(func(c *RenderConfig) { c.TimestampFormat = TimestampRelative })
+	future := fixedNow.Add(5 * time.Minute)
+	entry := parser.LogEntry{Timestamp: future, Message: "future"}
+	out := r.RenderEntryPlain(entry)
+	if !strings.Contains(out, "from now") {
+		t.Errorf("expected 'from now' for future timestamp: %q", out)
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.TerminalWidth != 120 {
+		t.Errorf("default width=%d, want 120", cfg.TerminalWidth)
+	}
+	if cfg.Theme != ThemeDark {
+		t.Error("default theme should be dark")
+	}
+	if cfg.ANSIMode != ANSIStrip {
+		t.Error("default ANSI mode should be strip")
+	}
+	if cfg.ShowAllFields {
+		t.Error("default should collapse fields")
+	}
+}


### PR DESCRIPTION
## Changes

Adds `internal/tui/renderer.go` — a log entry renderer using lipgloss with:

- **Color-coded log levels**: DEBUG (gray), INFO (blue), WARN (yellow), ERROR (red), FATAL (red bold)
- **Configurable timestamps**: relative ("5m ago"), ISO 8601, local time
- **Terminal-aware truncation/wrapping** based on configurable width
- **Collapsible extra fields** with configurable display order
- **ANSI escape code handling** (strip or pass-through)
- **Light and dark theme support**
- **20 comprehensive unit tests** in `renderer_test.go`

Fixes #4